### PR TITLE
Initial experiment with centralised package versions

### DIFF
--- a/Solutions/Common.NuGet.proj
+++ b/Solutions/Common.NuGet.proj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Operations.Abstractions/Marain.Operations.Abstractions.csproj
+++ b/Solutions/Marain.Operations.Abstractions/Marain.Operations.Abstractions.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   
   <PropertyGroup>
@@ -15,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Tenancy.Abstractions" Version="2.0.6" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <PackageReference Include="Corvus.Tenancy.Abstractions"  />
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Menes.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    </PackageReference> -->
+    <PackageReference Include="Menes.Abstractions"  />
+    <PackageReference Include="Newtonsoft.Json"  />
   </ItemGroup>
 
 </Project>

--- a/Solutions/Marain.Operations.Api.Specs/Marain.Operations.Api.Specs.csproj
+++ b/Solutions/Marain.Operations.Api.Specs/Marain.Operations.Api.Specs.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -16,15 +17,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Configuration.TestEnvironment" Version="1.2.2" />
-    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow" Version="1.4.1" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <PackageReference Include="Corvus.Configuration.TestEnvironment"  />
+    <PackageReference Include="Corvus.Testing.AzureFunctions.SpecFlow"  />
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    </PackageReference> -->
+    <PackageReference Include="Marain.Services.Tenancy.Testing"  />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit"  />
+    <PackageReference Include="NUnit3TestAdapter"  />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="ServiceManifests\" />

--- a/Solutions/Marain.Operations.Azure.Storage/Marain.Operations.Azure.Storage.csproj
+++ b/Solutions/Marain.Operations.Azure.Storage/Marain.Operations.Azure.Storage.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -15,10 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    </PackageReference> -->
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Operations.ControlClient/Marain.Operations.ControlClient.csproj
+++ b/Solutions/Marain.Operations.ControlClient/Marain.Operations.ControlClient.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
 
   <!--
   Not using normal netstandard2.0 import, because this contains AutoRest-generated code, which makes
@@ -33,12 +34,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.15" />
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication"  />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Operations.ControlHost.Functions/Marain.Operations.ControlHost.Functions.csproj
+++ b/Solutions/Marain.Operations.ControlHost.Functions/Marain.Operations.ControlHost.Functions.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -13,15 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Azure.Storage.Tenancy" Version="2.0.6" />
-    <PackageReference Include="Corvus.Monitoring.ApplicationInsights" Version="1.2.0" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <PackageReference Include="Corvus.Azure.Storage.Tenancy"  />
+    <PackageReference Include="Corvus.Monitoring.ApplicationInsights"  />
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.15" />
+    </PackageReference> -->
+    <PackageReference Include="Microsoft.NET.Sdk.Functions"  />
+    <PackageReference Include="Microsoft.OpenApi.Readers"  />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Operations.Hosting.AspNetCore/Marain.Operations.Hosting.AspNetCore.csproj
+++ b/Solutions/Marain.Operations.Hosting.AspNetCore/Marain.Operations.Hosting.AspNetCore.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -15,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication" Version="1.0.6" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <PackageReference Include="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication"  />
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Marain.Tenancy.ClientTenantProvider" Version="1.1.10" />
-    <PackageReference Include="Menes.Hosting.AspNetCore" Version="2.0.1" />
+    </PackageReference> -->
+    <PackageReference Include="Marain.Tenancy.ClientTenantProvider"  />
+    <PackageReference Include="Menes.Hosting.AspNetCore"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Marain.Operations.OpenApi/Marain.Operations.OpenApi.csproj
+++ b/Solutions/Marain.Operations.OpenApi/Marain.Operations.OpenApi.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -24,11 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Marain.Services.Tenancy" Version="2.3.3" />
+    </PackageReference> -->
+    <PackageReference Include="Marain.Services.Tenancy"  />
   </ItemGroup>
 
 </Project>

--- a/Solutions/Marain.Operations.Specs/Marain.Operations.Specs.csproj
+++ b/Solutions/Marain.Operations.Specs/Marain.Operations.Specs.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,12 +9,12 @@
     <RootNamespace>Marain.Operations.Specs</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Corvus.Configuration.TestEnvironment" Version="1.2.2" />
-    <PackageReference Include="Corvus.SpecFlow.Extensions" Version="0.6.0" />
-    <PackageReference Include="Marain.Services.Tenancy.Testing" Version="2.3.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.15" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.4.1" />
+    <PackageReference Include="Corvus.Configuration.TestEnvironment"  />
+    <PackageReference Include="Corvus.SpecFlow.Extensions"  />
+    <PackageReference Include="Marain.Services.Tenancy.Testing"  />
+    <PackageReference Include="Microsoft.Extensions.Configuration"  />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"  />
+    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit"  />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Marain.Operations.Abstractions\Marain.Operations.Abstractions.csproj" />

--- a/Solutions/Marain.Operations.StatusClient/Marain.Operations.StatusClient.csproj
+++ b/Solutions/Marain.Operations.StatusClient/Marain.Operations.StatusClient.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
 
   <!--
   Not using normal netstandard2.0 import, because this contains AutoRest-generated code, which makes
@@ -34,12 +35,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.23" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime"  />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Update="Microsoft.SourceLink.GitHub" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Solutions/Marain.Operations.StatusHost.Functions/Marain.Operations.StatusHost.Functions.csproj
+++ b/Solutions/Marain.Operations.StatusHost.Functions/Marain.Operations.StatusHost.Functions.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.1" />
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
@@ -13,15 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Corvus.Monitoring.ApplicationInsights" Version="1.2.0" />
-    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob" Version="2.0.6" />
-    <PackageReference Include="Endjin.RecommendedPractices" Version="1.2.0">
+    <PackageReference Include="Corvus.Monitoring.ApplicationInsights"  />
+    <PackageReference Include="Corvus.Tenancy.Storage.Azure.Blob"  />
+    <!-- <PackageReference Include="Endjin.RecommendedPractices" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.12" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.15" />
+    </PackageReference> -->
+    <PackageReference Include="Microsoft.NET.Sdk.Functions"  />
+    <PackageReference Include="Microsoft.OpenApi.Readers"  />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Packages.Corvus.proj
+++ b/Solutions/Packages.Corvus.proj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Update="Corvus.Configuration.TestEnvironment"                          Version="[1.2.2]" />
+    <PackageReference Update="Corvus.Monitoring.ApplicationInsights"                         Version="[1.2.0]" />
+    <PackageReference Update="Corvus.Identity.ManagedServiceIdentity.ClientAuthentication"   Version="[1.0.6]" />
+    <PackageReference Update="Corvus.Azure.Storage.Tenancy"                                  Version="[2.0.6]" />
+    <PackageReference Update="Corvus.SpecFlow.Extensions"                                    Version="[0.6.0]" />
+    <PackageReference Update="Corvus.Tenancy.Abstractions"                                   Version="[2.0.6]" />
+    <PackageReference Update="Corvus.Tenancy.Storage.Azure.Blob"                             Version="[2.0.6]" />
+    <PackageReference Update="Corvus.Testing.SpecFlow.NUnit"                                 Version="[1.4.1]" />
+    <PackageReference Update="Corvus.Testing.AzureFunctions.SpecFlow"                        Version="[1.4.1]" />
+  </ItemGroup>
+</Project>

--- a/Solutions/Packages.Microsoft.proj
+++ b/Solutions/Packages.Microsoft.proj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Sdk.Functions"                                   Version="[3.0.12]" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console"                          Version="[3.1.15]" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions"         Version="[3.1.15]" />
+    <PackageReference Update="Microsoft.Extensions.Configuration"                            Version="[3.1.15]" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub"                                   Version="[1.0.0-beta2-19367-01]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.OpenApi.Readers"                                     Version="[1.2.3]" />
+    <PackageReference Update="Microsoft.Rest.ClientRuntime"                                  Version="[2.3.23]" />
+  </ItemGroup>
+</Project>

--- a/Solutions/Packages.props
+++ b/Solutions/Packages.props
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Packages.Microsoft.proj" />
+  <Import Project="Packages.Corvus.proj" />
+
+  <ItemGroup>
+    <PackageReference Update="Newtonsoft.Json"                                               Version="[11.0.2]" />
+    <PackageReference Update="NUnit3TestAdapter"                                             Version="[3.17.0]" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Update="Endjin.RecommendedPractices"                                   Version="[1.2.0]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Marain.Tenancy.ClientTenantProvider"                           Version="[1.1.10]" />
+    <PackageReference Update="Marain.Services.Tenancy"                                       Version="[2.3.3]" />
+    <PackageReference Update="Marain.Services.Tenancy.Testing"                               Version="[2.3.3]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Menes.Abstractions"                                            Version="[2.0.1]" />
+    <PackageReference Update="Menes.Hosting.AspNetCore"                                      Version="[2.0.1]" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`Endjin.RecommendedPractices` temporarily disabled as the package references it contains clashes with this centralised approach.